### PR TITLE
Limpiar y espaciar fotos circularmente

### DIFF
--- a/ccs-2.css
+++ b/ccs-2.css
@@ -2063,9 +2063,9 @@ html, body { overflow-x: hidden; }
 
 /* Carrusel: borde blanco visible en imágenes y centrado; 3 en desktop, 1 en móvil */
 .gallery-section .carousel-container { margin-left: auto !important; margin-right: auto !important; }
-.gallery-section .carousel-track { display: flex !important; justify-content: center !important; gap: 1rem !important; }
+.gallery-section .carousel-track { display: flex !important; justify-content: flex-start !important; gap: 0 !important; }
 /* Desktop: 3 simultáneamente */
-.gallery-section .carousel-item { flex: 0 0 calc(33.333% - 0.666rem) !important; max-width: calc(33.333% - 0.666rem) !important; }
+.gallery-section .carousel-item { flex: 0 0 33.333% !important; max-width: 33.333% !important; }
 /* Imágenes con borde blanco y leve sombra */
 .gallery-section .carousel-item img { border: 4px solid #ffffff !important; border-radius: 6px !important; box-shadow: 0 6px 16px rgba(0,0,0,0.12) !important; }
 /* Móvil: 1 por vista, centrado */

--- a/java2.js
+++ b/java2.js
@@ -313,10 +313,18 @@ function initializeCarousel() {
         track.style.transition = enabled ? 'transform 0.5s ease-in-out' : 'none';
         isTransitioning = enabled;
     };
-    const perSlidePercent = () => 100 / visibleSlides;
+
+    // Medir ancho real de una diapositiva para desplazar en píxeles (evita huecos)
+    const getSlideWidthPx = () => {
+        const anySlide = track.querySelector('.carousel-item');
+        if (!anySlide) return 0;
+        const rect = anySlide.getBoundingClientRect();
+        return Math.round(rect.width);
+    };
     const translateTo = () => {
-        const translateX = -(index) * perSlidePercent();
-        track.style.transform = `translateX(${translateX}%)`;
+        const slideWidthPx = getSlideWidthPx();
+        const translateX = -(index) * slideWidthPx;
+        track.style.transform = `translate3d(${translateX}px, 0, 0)`;
     };
 
     // Primera posición (sin animación)
@@ -372,15 +380,18 @@ function initializeCarousel() {
     // Reinit básico en resize (reconstruir clones)
     window.addEventListener('resize', () => {
         const newVisible = getVisibleSlides();
-        if (newVisible === visibleSlides) return;
-        // Reset: limpiar y reconstruir
+        if (newVisible === visibleSlides) {
+            // Solo actualizar la posición con el nuevo ancho
+            setTransition(false);
+            translateTo();
+            requestAnimationFrame(() => setTransition(true));
+            return;
+        }
+        // Reset: limpiar y reconstruir cuando cambia el número visible
         setTransition(false);
-        // Eliminar todos los hijos
         track.innerHTML = '';
-        // Reagregar solo originales
         originalItems.forEach(n => track.appendChild(n));
         track.dataset.loopInit = '';
-        // Re-inicializar
         initializeCarousel();
     }, { passive: true });
 


### PR DESCRIPTION
Remove empty spaces and ensure uniform, continuous looping in the carousel.

The previous percentage-based displacement and CSS `gap` combined with `justify-content: center` led to visual gaps and inconsistent spacing. Switching to pixel-based calculations and removing explicit gaps ensures precise, uniform alignment and a smooth, continuous loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-feccf8a7-d0c6-4c5f-813d-5854f476e477">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-feccf8a7-d0c6-4c5f-813d-5854f476e477">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

